### PR TITLE
Update init.lua

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -15,6 +15,7 @@ local mq = require('mq')
 require('ImGui')
 
 local terminate, isOpen, shouldDraw = false, true, true
+local debug = false  -- Set this to false to disable debug prints
 
 local Raids = require('raidhud.raid-list')
 
@@ -25,6 +26,7 @@ local function updateRaidStatus()
             if eventIndex ~= nil then
                 Raids[i].events[ii].available = false
                 Raids[i].events[ii].lockedout = tostring(mq.TLO.Window("DynamicZoneWnd/DZ_TimerList").List(eventIndex,1))
+                Raids[i].events[ii].expedition = tostring(mq.TLO.Window("DynamicZoneWnd/DZ_TimerList").List(eventIndex,2))
             end
         end
     end
@@ -34,19 +36,48 @@ local function updateUI()
     if not isOpen then return end
     isOpen, shouldDraw = ImGui.Begin('RaidHUD', isOpen)
     if shouldDraw then
+        local io = ImGui.GetIO()
+        local ctrl_down = io.KeyCtrl
+        
         for _, era in ipairs(Raids) do
             if (ImGui.CollapsingHeader(era.era)) then
                 for _, event in ipairs(era.events) do
                     if event.available == true then
-                        ImGui.BulletText(event.name);
+                        ImGui.BulletText(event.name)
                         if ImGui.IsItemHovered() then
-                            ImGui.SetTooltip(event.tooltip);
+                            ImGui.SetTooltip(event.tooltip)
+                        end
+                        if ImGui.IsItemClicked() then
+                            if debug then print("Item clicked: " .. event.name) end
+                            if ctrl_down then
+                                if debug then print("Control key is down") end
+                                local travelto_command = event.tooltip:match("/travelto (%w+)")
+                                if travelto_command then
+                                    if debug then print("Executing command: /travelto " .. travelto_command) end
+                                    mq.cmdf("/travelto %s", travelto_command)
+                                end
+                            else
+                                print("Hold the control key to execute the travelto command")
+                            end
                         end
                     else
                         ImGui.Bullet()
-                        ImGui.TextDisabled(event.name);
+                        ImGui.TextDisabled(event.name)
                         if ImGui.IsItemHovered() then
-                            ImGui.SetTooltip("Lockout time: " .. event.lockedout);
+                            ImGui.SetTooltip("Lockout time: " .. event.lockedout .. "\nExpedition: " .. event.expedition)
+                        end
+                        if ImGui.IsItemClicked() then
+                            if debug then print("Item clicked: " .. event.name) end
+                            if ctrl_down then
+                                if debug then print("Control key is down") end
+                                local travelto_command = event.tooltip:match("/travelto (%w+)")
+                                if travelto_command then
+                                    if debug then print("Executing command: /travelto " .. travelto_command) end
+                                    mq.cmdf("/travelto %s", travelto_command)
+                                end
+                            else
+                                print("Hold the control key to execute the travelto command")
+                            end
                         end
                     end
                 end


### PR DESCRIPTION
Added expedition name and /travelto command. Executing the travelto requires depressing the ctrl key while left clicking the raid. Failure to depress ctrl but clicking will print a message stating such.